### PR TITLE
fix tag regexp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ configurations {
 
 version = {
     def vd = versionDetails()
-    if (vd.commitDistance == 0 && vd.lastTag ==~ /^v[0-9]+\.[0-9]+\.[0-9]+(\.[a-zA-Z0-9]+)?/) {
+    if (vd.commitDistance == 0 && vd.lastTag ==~ /^v[0-9]+\.[0-9]+\.[0-9]+-trocco-[0-9]+\.[0-9]+\.[0-9]+$/) {
         vd.lastTag.substring(1)
     } else {
         "0.0.0.${vd.gitHash}"


### PR DESCRIPTION
versioning policy in this repo is `${base repository version}-trocco-${original version}`.
e.g. `0.1.7-trocco-0.0.1`