### PR TITLE
bump Simba Athena JDBC driver to AthenaJDBC42

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Athena input plugin for Embulk loads records from Athena(AWS).
 
 ## Configuration
 
-* **driver_path**: path to the jar file of the Athena JDBC driver. If not set, the bundled JDBC driver(AthenaJDBC41.jar) will be used. (string)
+* **driver_path**: path to the jar file of the Athena JDBC driver. If not set, the bundled JDBC driver(AthenaJDBC42-2.2.4.1000.jar) will be used. (string)
 * **database**: database name (string, required)
 * **athena_url**: Athena url (string, required)
 * **s3_staging_dir**: The S3 location to which your query output is written, for example s3://query-results-bucket/folder/. (string, required)

--- a/build.gradle
+++ b/build.gradle
@@ -34,13 +34,13 @@ dependencies {
     compile("org.embulk:embulk-util-config:0.3.0")
 
     // TODO: maven...
-    compile files ('build/AthenaJDBC41.jar')
+    compile files ('build/AthenaJDBC42-2.2.4.1000.jar')
     compile 'org.embulk:embulk-input-jdbc:0.12.2'
     testCompile "junit:junit:4.+"
 }
 
 task downloadFile(type: Download) {
-    src 'https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC-2.0.23.1000/AthenaJDBC41.jar'
+    src 'https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/SimbaAthenaJDBC-2.2.4.1000/AthenaJDBC42-2.2.4.1000.jar'
     dest buildDir
     onlyIfModified true
 }


### PR DESCRIPTION
AthenaJDBC41 uses AWS SDK v1 that was expired in Dec 2025.
