### PR TITLE
bump Athena JDBC to v3 (for AWS SDK v2) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Athena input plugin for Embulk loads records from Athena(AWS).
 
 ## Configuration
 
-* **driver_path**: path to the jar file of the Athena JDBC driver. If not set, the bundled JDBC driver(AthenaJDBC41.jar) will be used. (string)
+* **driver_path**: path to the jar file of the Athena JDBC driver. If not set, the bundled JDBC driver (athena-jdbc-3.7.0-with-dependencies.jar) will be used. (string)
 * **database**: database name (string, required)
 * **athena_url**: Athena url (string, required)
 * **s3_staging_dir**: The S3 location to which your query output is written, for example s3://query-results-bucket/folder/. (string, required)
@@ -34,7 +34,7 @@ Athena input plugin for Embulk loads records from Athena(AWS).
 in:
   type: athena
   database: log_test
-  athena_url: "jdbc:awsathena://athena.ap-northeast-1.amazonaws.com:443"
+  athena_url: "jdbc:athena://athena.ap-northeast-1.amazonaws.com:443"
   s3_staging_dir: "s3://aws-athena-query-results-11111111111-ap-northeast-1/"
   access_key: ""
   secret_key: ""
@@ -50,7 +50,7 @@ in:
 in:
   type: athena
   database: log_test
-  athena_url: "jdbc:awsathena://athena.ap-northeast-1.amazonaws.com:443"
+  athena_url: "jdbc:athena://athena.ap-northeast-1.amazonaws.com:443"
   s3_staging_dir: "s3://aws-athena-query-results-11111111111-ap-northeast-1/"
   access_key: ""
   secret_key: ""

--- a/build.gradle
+++ b/build.gradle
@@ -34,13 +34,13 @@ dependencies {
     compile("org.embulk:embulk-util-config:0.3.0")
 
     // TODO: maven...
-    compile files ('build/AthenaJDBC41.jar')
+    compile files ('build/athena-jdbc-3.7.0-with-dependencies.jar')
     compile 'org.embulk:embulk-input-jdbc:0.12.2'
     testCompile "junit:junit:4.+"
 }
 
 task downloadFile(type: Download) {
-    src 'https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC-2.0.23.1000/AthenaJDBC41.jar'
+    src 'https://downloads.athena.us-east-1.amazonaws.com/drivers/JDBC/3.7.0/athena-jdbc-3.7.0-with-dependencies.jar'
     dest buildDir
     onlyIfModified true
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ configurations {
 
 version = {
     def vd = versionDetails()
-    if (vd.commitDistance == 0 && vd.lastTag ==~ /^v[0-9]+\.[0-9]+\.[0-9]+-trocco-[0-9]+\.[0-9]+\.[0-9]+$/) {
+    if (vd.lastTag ==~ /^v[0-9]+\.[0-9]+\.[0-9]+-trocco-[0-9]+\.[0-9]+\.[0-9]+$/) {
         vd.lastTag.substring(1)
     } else {
         "0.0.0.${vd.gitHash}"

--- a/build.gradle
+++ b/build.gradle
@@ -15,14 +15,7 @@ configurations {
     provided
 }
 
-version = {
-    def vd = versionDetails()
-    if (vd.lastTag ==~ /^v[0-9]+\.[0-9]+\.[0-9]+-trocco-[0-9]+\.[0-9]+\.[0-9]+$/) {
-        vd.lastTag.substring(1)
-    } else {
-        "0.0.0.${vd.gitHash}"
-    }
-}()
+version = versionDetails().lastTag.substring(1)
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/org/embulk/input/athena/AthenaInputPlugin.java
+++ b/src/main/java/org/embulk/input/athena/AthenaInputPlugin.java
@@ -328,6 +328,14 @@ public class AthenaInputPlugin implements InputPlugin
             url = "jdbc:athena://" + url.substring("jdbc:awsathena://".length());
             logger.info("Converted deprecated URL prefix 'jdbc:awsathena://' to 'jdbc:athena://'");
         }
+        if (!properties.containsKey("Region")) {
+            java.util.regex.Matcher m = java.util.regex.Pattern
+                    .compile("athena\\.([a-z0-9-]+)\\.amazonaws\\.com")
+                    .matcher(url);
+            if (m.find()) {
+                properties.put("Region", m.group(1));
+            }
+        }
         return DriverManager.getConnection(url, properties);
     }
     

--- a/src/main/java/org/embulk/input/athena/AthenaInputPlugin.java
+++ b/src/main/java/org/embulk/input/athena/AthenaInputPlugin.java
@@ -315,12 +315,12 @@ public class AthenaInputPlugin implements InputPlugin
 
     protected Connection getAthenaConnection(PluginTask task) throws ClassNotFoundException, SQLException
     {
-        loadDriver("com.simba.athena.jdbc.Driver", task.getDriverPath());
+        loadDriver("com.amazon.athena.jdbc.AthenaDriver", task.getDriverPath());
         Properties properties = new Properties();
-        properties.put("s3_staging_dir", task.getS3StagingDir());
-        properties.put("user", task.getAccessKey());
-        properties.put("password", task.getSecretKey());
-        properties.put("schema", task.getDatabase());
+        properties.put("OutputLocation", task.getS3StagingDir());
+        properties.put("User", task.getAccessKey());
+        properties.put("Password", task.getSecretKey());
+        properties.put("Database", task.getDatabase());
         properties.putAll(task.getOptions());
 
         return DriverManager.getConnection(task.getAthenaUrl(), properties);

--- a/src/main/java/org/embulk/input/athena/AthenaInputPlugin.java
+++ b/src/main/java/org/embulk/input/athena/AthenaInputPlugin.java
@@ -323,7 +323,12 @@ public class AthenaInputPlugin implements InputPlugin
         properties.put("Database", task.getDatabase());
         properties.putAll(task.getOptions());
 
-        return DriverManager.getConnection(task.getAthenaUrl(), properties);
+        String url = task.getAthenaUrl();
+        if (url.startsWith("jdbc:awsathena://")) {
+            url = "jdbc:athena://" + url.substring("jdbc:awsathena://".length());
+            logger.info("Converted deprecated URL prefix 'jdbc:awsathena://' to 'jdbc:athena://'");
+        }
+        return DriverManager.getConnection(url, properties);
     }
     
     private ColumnGetterFactory newColumnGetterFactory(PageBuilder pageBuilder, ZoneId dateTimeZone)


### PR DESCRIPTION
AthenaJDBC41 uses AWS SDK v1 that was expired in Dec 2025.
